### PR TITLE
Add ICLR 2026 paper: MOSIV

### DIFF
--- a/papers/iclr2026/liu_mosiv.txt
+++ b/papers/iclr2026/liu_mosiv.txt
@@ -1,0 +1,6 @@
+title:: MOSIV: Multi-Object System Identification from Videos
+authors:: Chunjiang Liu, Xiaoyuan Wang, Qingran Lin, Albert Xiao, Haoyu Chen, Shizheng Wen, Hao Zhang, Lu Qi, Ming-Hsuan Yang, Laszlo A. Jeni, Min Xu, Yizhou Zhao
+url:: https://arxiv.org/abs/2603.06022
+pdf:: https://arxiv.org/pdf/2603.06022.pdf
+conference:: ICLR
+year:: 2026


### PR DESCRIPTION
## Summary
- Add ICLR 2026 paper: **MOSIV: Multi-Object System Identification from Videos**
- Authors: Chunjiang Liu, Xiaoyuan Wang, Qingran Lin, Albert Xiao, Haoyu Chen, Shizheng Wen, Hao Zhang, Lu Qi, Ming-Hsuan Yang, Laszlo A. Jeni, Min Xu, Yizhou Zhao
- Paper file: `papers/iclr2026/liu_mosiv.txt`