### PR TITLE
Added RobotArena Infinity -- Jangir et al.

### DIFF
--- a/papers/iclr2026/jangir_robotarena_infinity.txt
+++ b/papers/iclr2026/jangir_robotarena_infinity.txt
@@ -1,0 +1,6 @@
+title:: RobotArena ∞: Scalable Robot Benchmarking via Real-to-Sim Translation
+authors:: Yash Jangir, Yidi Zhang, Kashu Yamazaki, Chenyu Zhang, Kuan-Hsun Tu, Tsung-Wei Ke, Lei Ke, Yonatan Bisk, Katerina Fragkiadaki
+url:: https://arxiv.org/abs/2510.23571
+pdf:: https://arxiv.org/pdf/2510.23571.pdf
+conference:: ICLR
+year:: 2026

--- a/projects/2026_RobotArenaInfinity.txt
+++ b/projects/2026_RobotArenaInfinity.txt
@@ -1,0 +1,5 @@
+title:: RobotArena ∞: Scalable Robot Benchmarking via Real-to-Sim Translation
+url:: https://robotarenainf.github.io/
+img:: https://robotarenainf.github.io/static/images/teaser.jpg
+year:: 2026
+topics:: Robotics, 3D Vision


### PR DESCRIPTION
Adds RobotArena ∞ (Jangir et al., ICLR 2026) to the publications list. Includes title, authors, and link.